### PR TITLE
fix: broken links in course member list

### DIFF
--- a/views/course/members/accepted_list.php
+++ b/views/course/members/accepted_list.php
@@ -74,7 +74,7 @@
             <? endif ?>
                 <td style="text-align: right"><?= sprintf('%02u', ++$nr) ?></td>
                 <td>
-                    <a href="<?= $controller->url_for('profile?username=' . $accept['username']) ?>" <? if ($accept['mkdate'] >= $last_visitdate) echo 'class="new-member"'; ?>>
+                    <a href="<?= URLHelper::getLink('dispatch.php/profile?username=' . $accept['username']) ?>" <? if ($accept['mkdate'] >= $last_visitdate) echo 'class="new-member"'; ?>>
                         <?= Avatar::getAvatar($accept['user_id'], $accept['username'])->getImageTag(Avatar::SMALL, [
                             'style' => 'margin-right: 5px',
                             'title' => $fullname,

--- a/views/course/members/autor_list.php
+++ b/views/course/members/autor_list.php
@@ -90,7 +90,7 @@
             <? endif ?>
                 <td style="text-align: right"><?= sprintf('%02u', ++$nr) ?></td>
                 <td>
-                    <a href="<?= $controller->url_for('profile?username=' . $autor['username']) ?>" <? if ($autor['mkdate'] >= $last_visitdate) echo 'class="new-member"'; ?>>
+                    <a href="<?= URLHelper::getLink('dispatch.php/profile?username=' . $autor['username']) ?>" <? if ($autor['mkdate'] >= $last_visitdate) echo 'class="new-member"'; ?>>
                         <?= Avatar::getAvatar($autor['user_id'], $autor['username'])->getImageTag(Avatar::SMALL, [
                             'style' => 'margin-right: 5px',
                             'title' => $fullname,

--- a/views/course/members/awaiting_list.php
+++ b/views/course/members/awaiting_list.php
@@ -81,7 +81,7 @@
             <? endif ?>
                 <td style="text-align: right"><?= sprintf('%02d', ++$nr) ?></td>
                 <td>
-                    <a href="<?= $controller->url_for('profile?username=' . $waiting['username']) ?>" <? if ($waiting['mkdate'] >= $last_visitdate) echo 'class="new-member"'; ?>>
+                    <a href="<?= URLHelper::getLink('dispatch.php/profile?username=' . $waiting['username']) ?>" <? if ($waiting['mkdate'] >= $last_visitdate) echo 'class="new-member"'; ?>>
                         <?= Avatar::getAvatar($waiting['user_id'], $waiting['username'])->getImageTag(Avatar::SMALL, [
                             'style' => 'margin-right: 5px',
                             'title' => $fullname,


### PR DESCRIPTION
Moin Moin,
in der Kursübersicht waren die Links zu den Teilnehmern kaputt. (z.B. hier https://ammerland.elan-ev.de/plugins.php/studip_vhs/seminar?cid=435c99188a3db64df87d0523f32ebc1d - wurde im System aber schon von Elmar korrigiert)
Ich habe den Fehler von Frau Bittner gemeldet bekommen und dann mit Hilfe von Elmar direkt auf dem Server gefixt.
Die drei Änderungen waren nötig und da ich keine Rechte in dem Repository habe, jetzt dieser PR.

An sich nichts kritisches, scheinbar ist der Fehler auch nur im Branch studip_42 vorhanden.