### PR TITLE
fix uninitialized array from error_log

### DIFF
--- a/Studip_VHS.php
+++ b/Studip_VHS.php
@@ -250,6 +250,7 @@ class Studip_VHS extends StudIPPlugin implements StandardPlugin, SystemPlugin
         global $perm;
         $restNavigation = array();
         $newNavigation = Navigation::getItem('/course');
+        $subNavigations = array();
         foreach(Navigation::getItem('/course') as $key => $tab){
             $block = SeminarTab::findOneBySQL('seminar_id = ? AND tab IN (?) ORDER BY position ASC',
                                      array($this->course_id,$key) );


### PR DESCRIPTION
Im error_log sind Zeilen enthalten wie:
`
[Wed Apr 21 14:59:08.132007 2021] [:error] [pid xxxx] [client xxx.xxx.xxx.xxx:xxxxx] PHP Warning:  Invalid argument supplied for foreach() in […]/public/plugins_packages/elan-ev/Studip_VHS/Studip_VHS.php on line 271, referer: https:/[…]/plugins.php/etherpadplugin/pads/iframe/testpad?cid=xxx`